### PR TITLE
feat(gh-workflows): replace ETH with LYXt on git actions

### DIFF
--- a/.github/workflows/replace-currency.yml
+++ b/.github/workflows/replace-currency.yml
@@ -1,0 +1,37 @@
+name: replace-currency
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  currency-replace:
+    runs-on: ubuntu-latest
+    name: A job to find and replace chain currency symbol
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Find and Replace
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: "ETH"
+          replace: "LYXt"
+          regex: true
+          exclude: ".github/**"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Find and replace currency
+          title: '[Automated PR] Find and replace currency'
+          delete-branch: true
+          body: |
+            Found currency instances that can be replaced. Please review
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/replace-currency.yml
+++ b/.github/workflows/replace-currency.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: main
           fetch-depth: 0
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@v2

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -21,8 +21,8 @@ chain:
 frontend:
   enabled: true # Enable or disable to web frontend
   imprint: "templates/imprint.example.html}**"  # Path to the imprint page content
-  siteName: "Ethereum 2.0 Beacon Chain (Phase 0) Block Chain Explorer" # Name of the site, displayed in the title tag
-  siteSubtitle: "Showing the <a href='https://prylabs.net'>💎 Prysm Eth2 Testnet</a>" # Subtitle shown on the main page
+  siteName: "Lukso L16 Testnet Block Chain Explorer" # Name of the site, displayed in the title tag
+  siteSubtitle: "Showing the <a href='https://prylabs.net'>💎 L16 Testnet</a>" # Subtitle shown on the main page
   csrfAuthKey: '0123456789abcdef000000000000000000000000000000000000000000000000'
   jwtSigningSecret: "0123456789abcdef000000000000000000000000000000000000000000000000"
   jwtIssuer: "beaconcha.in"


### PR DESCRIPTION
### Description

This PR introduces a Github Actions workflow that can both be manually triggered or triggered on successful commit to the `main/master` branch. This workflow attempts to replace all instances of currency `ETH` with `LYXt` and creates a follow-up PR for human review.

#### Clickup Task
#CU-31enrdr