### PR TITLE
fix: use a PAT to solve git crashing error

### DIFF
--- a/.github/workflows/replace-currency.yml
+++ b/.github/workflows/replace-currency.yml
@@ -25,6 +25,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.GH_TOKEN }}
           commit-message: Find and replace currency
           title: '[Automated PR] Find and replace currency'
           delete-branch: true


### PR DESCRIPTION
### Description

This PR introduces a fix for an error happening in the `create pull request` step of the currency replacement GH Actions workflow. The exit code `128` of the error is indeterminate but suggestions from the community tilt towards providing an explicit PAT to the third party action that is trying to create a pull request - and that is what was added in this PR.

*Screenshot:*
<img width="957" alt="image" src="https://user-images.githubusercontent.com/30433120/173520523-f41f035d-b197-41e1-9315-1c13f67adf65.png">
