### PR TITLE
Fix currency replacement false positives

### DIFF
--- a/.github/workflows/replace-currency.yml
+++ b/.github/workflows/replace-currency.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: "ETH"
+          find: '\bETH\b'
           replace: "LYXt"
           regex: true
           exclude: ".git**"


### PR DESCRIPTION
### Description

In the previous iteration of the main blockchain currency replacement workflow, there were false positives in the find-and-replace which ended up changing variable names and likely breaking the program. This PR introduces a fix using word-only regex